### PR TITLE
Revert "⬆ Bump pypa/gh-action-pypi-publish from 1.12.3 to 1.12.4 (#13…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           TIANGOLO_BUILD_PACKAGE: ${{ matrix.package }}
         run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@v1.12.3
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
…251)"

This reverts commit 0e2d8d64a427905d673ecee9cfeaf9e74ed979e4.